### PR TITLE
Fix exterior not defined in parse_wkt

### DIFF
--- a/src/wkt.jl
+++ b/src/wkt.jl
@@ -802,6 +802,7 @@ function parse_wkt(::Type{Polygon{2, Float64}}, tokens::AbstractVector{<:Abstrac
     if tokens[i] != "("
         throw(WKTParsingError("Error parsing POLYGON"))
     end
+    exterior = LineString{2, Float64, Vector{SVector{2, Float64}}}
     interiors = Vector{LineString{2, Float64, Vector{SVector{2, Float64}}}}()
     n_linestrings = 0
     i += 1
@@ -836,6 +837,7 @@ function parse_wkt(::Type{Polygon{3, Float64}}, tokens::AbstractVector{<:Abstrac
     if tokens[i] != "("
         throw(WKTParsingError("Error parsing POLYGON Z"))
     end
+    exterior = LineString{3, Float64, Vector{SVector{3, Float64}}}
     interiors = Vector{LineString{3, Float64, Vector{SVector{3, Float64}}}}()
     n_linestrings = 0
     i += 1


### PR DESCRIPTION
When using `read_wkt` function to read a well know text of a polygon with exterior and interior. There will be an error of `exterior` not defined in the function `parse_wkt`.

For example by:
```Julia
example_wkt = "POLYGON((-64.8 32.3, -65.5 18.3, -80.3 25.2, -64.8 32.3), (-68 27, -70.2 28.3, -69.2 25.2, -68 27))"

example_poly = read_wkt(example_wkt)
```
Will have the error of "ERROR: LoadError: UndefVarError: `exterior` not defined".


This is a fix for just simply define the `exterior` variable in the function `parse_wkt` related to polygons.