### PR TITLE
Filter to lines2

### DIFF
--- a/src/GridIndex.jl
+++ b/src/GridIndex.jl
@@ -267,7 +267,7 @@ findIndiciesClose2Lines(lines::AbstractVector{<:Line}, points::AcceleratedArray{
     Returns all point cloud indices inside selected grid cells, where the selected grid cells are thoes whose centre 
     are within a distance d of any of the given lines (note a 2D distance in the first 2 dimensions (ie x,y) is used).
 """
-function findIndiciesClose2LinesNew(lines::AbstractVector{<:Line}, points::AcceleratedArray{<:Any, <:Any, <:Any, <:GridIndex}, d::Float64)
+function findIndiciesClose2Lines(lines::AbstractVector{<:Line}, points::AcceleratedArray{<:Any, <:Any, <:Any, <:GridIndex}, d::Float64)
     grid = points.index
     lines = [convert2d(line) for line in lines]
 


### PR DESCRIPTION
this function is slow for the case of sparse PC ie when many of the grid cells are empty, I needed it to be real time for a human editing tool I'm writing. As this will affect a number of downstream things in master please have a close look at my changes. I used two test cases one is a standard tile with a single line:
pcW=RoamesGeometry.load_pointcloud("/home/greg/IntrusionDetection/VTT_Tile_1-570500_5241000.laz");
pc2 = RoamesGeometry.Table(
merge(
RoamesGeometry.columns(pcW),
(
position=RoamesGeometry.accelerate(
pcW.position,
GridIndex;
spacing=1.0
),
),
),
)
l2=Line(SVector(570554.743, 5241441.495, 0.0),SVector(570917.529, 5241081.065, 84.086))
@time new=RoamesGeometry.findIndiciesClose2LinesNew([l2],pc2.position,1.0);
gave:
0.057642 seconds (7.29 k allocations: 423.198 MiB, 15.21% gc time)
@time old=RoamesGeometry.findIndiciesClose2Lines([l2],pc2.position,1.0);
gave:
0.295011 seconds (2.44 M allocations: 504.163 MiB, 38.73% compilation time)
the tile in question looks like
image

The second case is a much larger grid with many empty elements but not a lot of points and looks like

image

the test fiels are here

gs://eq-c2rw-research/NetworkDetection/testDataBalgownie/pcFilteredToNetwork/

the PC was loaded as follows

localJLD2DirForPoints = "testingJLD2Files/"
files = filter(endswith(".jld2"),readdir(localJLD2DirForPoints,join=true))
probs = Float64[]
pc = RoamesGeometry.Table(position=SVector{3,Float64}[], classification=UInt8[], userdata=UInt8[], gpstime=Float64[], color=RGB{N0f16}[])
for f in files
dictionary = JLD2.load(f)
pcTemp = dictionary["pcNetwork"]
append!(pc, pcTemp)
append!(probs,dictionary["probsNetwork"])
end
pc = RoamesGeometry.Table(
merge(
RoamesGeometry.columns(pc),
(
position=RoamesGeometry.accelerate(
pc.position,
GridIndex;
spacing=1.0
),
),
),
)

the test line was
l=Line(SVector( 304302.773, 6192887.910, 54.096),SVector( 304319.418, 6192998.168, 47.224))
@time old=RoamesGeometry.findIndiciesClose2Lines([l],pc.position,1.0);
gave:
9.191290 seconds (62.71 M allocations: 1.988 GiB, 23.56% gc time)
@time new=RoamesGeometry.findIndiciesClose2LinesNew([l],pc.position,1.0);
gave:
0.021625 seconds (1.46 k allocations: 6.609 MiB)

for both test cases
sort(old)==sort(new)
is true ie the order changes but not the indicies

note this could probably be faster again but htis suits my purposes for the moment